### PR TITLE
Last Commits - Update Perft Function 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -131,7 +131,7 @@ namespace {
     ASSERT_ALIGNED(&st, Eval::NNUE::CacheLineSize);
 
     uint64_t cnt, nodes = 0;
-    const bool leaf = (depth == 2);
+    const bool leaf = (depth == 1);
 
     for (const auto& m : MoveList<LEGAL>(pos))
     {
@@ -140,7 +140,7 @@ namespace {
         else
         {
             pos.do_move(m, st);
-            cnt = leaf ? MoveList<LEGAL>(pos).size() : perft<false>(pos, depth - 1);
+            cnt = leaf ? 1 : perft<false>(pos, depth - 1);
             nodes += cnt;
             pos.undo_move(m);
         }

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 echo "perft testing started"
 
 cat << EOF > perft.exp
-   set timeout 10
+   set timeout 30
    lassign \$argv pos depth result
    spawn ./stockfish
    send "position \$pos\\ngo perft \$depth\\n"


### PR DESCRIPTION
Hi @vondele Please Read Just One Minute My Pull Request If It Was False Then Block Me 

Base of Crafty Chess Authors & All Other Chess Engine , The Perft Function Must Combine _**move generator**_ & _**make_move**_

https://github.com/MichaelB7/Crafty/blob/5501aa243bcb5fcf170791dd240017675960d152/src/option.c#L2280

https://github.com/MichaelB7/Crafty/blob/5501aa243bcb5fcf170791dd240017675960d152/src/option.c#L2295

In Current Version Of Stockfish Show 99 million NPS Speed That We Know It Is Unreal
This bug belongs to the last layer That **_make_move_** will not be executed & Only Run **_move generator_**

`MoveList<LEGAL>(pos).size()`

This Compare Show Real & Unreal Perft Speed At Depth 6 & Is Same All Other Chess Engine (Crafty , Komodo , Fritz , ....)

**Unreal Peft Speed**
```
Perft 6 leaf nodes: 119060324

===========================
Total time (ms) : 1192
Nodes searched  : 119060324
Nodes/second    : 99882822

```
**Real Peft Speed**
```
Perft 6 leaf nodes: 119060324

===========================
Total time (ms) : 6670
Nodes searched  : 119060324
Nodes/second    : 17850123
```

